### PR TITLE
Update ParseException.php

### DIFF
--- a/src/QueryPath/IOException.php
+++ b/src/QueryPath/IOException.php
@@ -13,7 +13,7 @@ namespace QueryPath;
  * @ingroup querypath_core
  */
 class IOException extends \QueryPath\ParseException {
-  public static function initializeFromError($code, $str, $file, $line, $cxt) {
+  public static function initializeFromError($code, $str, $file, $line, $cxt = NULL) {
     $class = __CLASS__;
     throw new $class($str, $code, $file, $line);
   }

--- a/src/QueryPath/ParseException.php
+++ b/src/QueryPath/ParseException.php
@@ -36,7 +36,7 @@ class ParseException extends \QueryPath\Exception {
     parent::__construct($msg, $code);
   }
 
-  public static function initializeFromError($code, $str, $file, $line, $cxt) {
+  public static function initializeFromError($code, $str, $file, $line, $cxt = NULL) {
     //printf("\n\nCODE: %s %s\n\n", $code, $str);
     $class = __CLASS__;
     throw new $class($str, $code, $file, $line);


### PR DESCRIPTION
the error context parameter was removed in php8, making it optional in the initializeFromError therefore.  